### PR TITLE
Change empty message from null to undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ class BaseError extends Error {
 	constructor(message, previous) {
 		if (message instanceof Error) {
 			previous = message;
-			message = null;
+			message = undefined;
 		}
 
 		if (previous && !(previous instanceof Error)) {


### PR DESCRIPTION
--- that is due to incorrect casting of null to 'null' by the parent class.